### PR TITLE
add haptics to primary app interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "lucide-react": "^0.563.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "web-haptics": "^0.0.6"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -7784,6 +7785,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-haptics": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/web-haptics/-/web-haptics-0.0.6.tgz",
+      "integrity": "sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18",
+        "svelte": ">=4",
+        "vue": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lucide-react": "^0.563.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "web-haptics": "^0.0.6"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/src/components/atoms/button.tsx
+++ b/src/components/atoms/button.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '../../lib/utils'
+import { triggerHaptic } from '../../lib/haptics'
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] active:brightness-90',
@@ -48,20 +49,53 @@ const buttonVariants = cva(
   },
 )
 
+type ButtonHaptic = 'auto' | 'none' | 'success' | 'nudge' | 'error' | 'buzz'
+
 export interface ButtonProps
   extends
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
+  haptic?: ButtonHaptic
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, fullWidth, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      variant,
+      size,
+      fullWidth,
+      asChild = false,
+      haptic = 'auto',
+      onClick,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : 'button'
+
+    const resolvedHaptic =
+      haptic === 'auto'
+        ? variant === 'danger'
+          ? 'error'
+          : size === 'icon'
+            ? 'none'
+            : 'nudge'
+        : haptic
+
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, fullWidth, className }))}
         ref={ref}
+        disabled={disabled}
+        onClick={(event: React.MouseEvent<HTMLElement>) => {
+          if (!disabled && resolvedHaptic !== 'none') {
+            triggerHaptic(resolvedHaptic)
+          }
+          onClick?.(event as React.MouseEvent<HTMLButtonElement>)
+        }}
         {...props}
       />
     )

--- a/src/components/screens/MainMenu.tsx
+++ b/src/components/screens/MainMenu.tsx
@@ -9,6 +9,7 @@ import { Icon } from '../atoms'
 import { MysticDivider } from '../items'
 import { useShaderBackground } from '../../hooks/useShaderBackground'
 import { cn } from '../../lib/utils'
+import { triggerHaptic } from '../../lib/haptics'
 
 // =============================================================================
 // GRIMOIRE BACKGROUND SHADER
@@ -200,19 +201,23 @@ export function MainMenu({
 
   const handleBreakSeal = useCallback(() => {
     if (phase !== 'sealed') return
+    triggerHaptic('nudge')
     setPhase('breaking')
     setTimeout(() => {
       hasOpenedGrimoire = true
       setPhase('open')
+      triggerHaptic('success')
     }, 700)
   }, [phase])
 
   const openPastGames = useCallback(() => {
+    triggerHaptic('nudge')
     setShowPastGames(true)
     setPastGamesClosing(false)
   }, [])
 
   const closePastGames = useCallback(() => {
+    triggerHaptic('nudge')
     setPastGamesClosing(true)
     setTimeout(() => {
       setShowPastGames(false)
@@ -408,7 +413,10 @@ export function MainMenu({
                     }
                   >
                     <button
-                      onClick={() => onContinue(currentGame.id)}
+                      onClick={() => {
+                        triggerHaptic('success')
+                        onContinue(currentGame.id)
+                      }}
                       className='relative w-full p-5 rounded-xl bg-gradient-to-r from-mystic-gold/15 to-mystic-bronze/10 border border-mystic-gold/25 card-border-glow transition-all group'
                       style={
                         {
@@ -446,7 +454,10 @@ export function MainMenu({
                   }
                 >
                   <button
-                    onClick={onNewGame}
+                    onClick={() => {
+                      triggerHaptic('success')
+                      onNewGame()
+                    }}
                     className='relative w-full p-5 rounded-xl bg-gradient-to-r from-indigo-900/40 to-purple-900/30 border border-indigo-500/25 card-border-glow transition-all group'
                     style={
                       {
@@ -483,7 +494,10 @@ export function MainMenu({
                 }
               >
                 <button
-                  onClick={onHowToPlay}
+                  onClick={() => {
+                    triggerHaptic('nudge')
+                    onHowToPlay()
+                  }}
                   className='text-sm text-parchment-400 hover:text-parchment-200 underline underline-offset-4 decoration-1 decoration-parchment-500/40 transition-colors tracking-wider'
                 >
                   {t.howToPlay.title}
@@ -492,7 +506,10 @@ export function MainMenu({
                 <span className='text-parchment-500/40 hidden sm:inline'>·</span>
 
                 <button
-                  onClick={onRolesLibrary}
+                  onClick={() => {
+                    triggerHaptic('nudge')
+                    onRolesLibrary()
+                  }}
                   className='text-sm text-parchment-400 hover:text-parchment-200 underline underline-offset-4 decoration-1 decoration-parchment-500/40 transition-colors tracking-wider'
                 >
                   {t.mainMenu.rolesLibrary}
@@ -562,6 +579,7 @@ export function MainMenu({
                   <button
                     key={game.id}
                     onClick={() => {
+                      triggerHaptic('success')
                       closePastGames()
                       onLoadGame(game.id)
                     }}

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,47 @@
+import { WebHaptics } from 'web-haptics'
+
+const HAPTICS_ENABLED_KEY = 'grimorium:haptics:enabled'
+
+type HapticPreset = 'success' | 'nudge' | 'error' | 'buzz'
+
+let haptics: WebHaptics | null = null
+
+function canUseBrowserApis() {
+  return typeof window !== 'undefined' && typeof navigator !== 'undefined'
+}
+
+function getClientHaptics() {
+  if (!canUseBrowserApis()) return null
+  if (!haptics) {
+    haptics = new WebHaptics()
+  }
+  return haptics
+}
+
+function prefersReducedMotion() {
+  if (!canUseBrowserApis() || !window.matchMedia) return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export function isHapticsEnabled() {
+  if (!canUseBrowserApis()) return false
+
+  const stored = window.localStorage.getItem(HAPTICS_ENABLED_KEY)
+  if (stored === 'false') return false
+
+  return !prefersReducedMotion()
+}
+
+export function setHapticsEnabled(enabled: boolean) {
+  if (!canUseBrowserApis()) return
+  window.localStorage.setItem(HAPTICS_ENABLED_KEY, String(enabled))
+}
+
+export function triggerHaptic(preset: HapticPreset = 'nudge') {
+  if (!isHapticsEnabled()) return
+
+  const client = getClientHaptics()
+  if (!client) return
+
+  void client.trigger(preset)
+}


### PR DESCRIPTION
## Summary
- add a centralized `lib/haptics` wrapper around `web-haptics` with graceful fallback and reduced-motion/localStorage opt-out support
- wire haptic feedback into the shared `Button` atom, with sensible defaults (`nudge`) and stronger feedback for destructive actions (`danger` -> `error`)
- add explicit haptics to Main Menu high-value flows (open grimoire, continue/new game, navigation links, and loading past games)

## Why
- closes #22 by integrating haptics into real interaction flows rather than adding dormant plumbing
- keeps the integration maintainable via a shared trigger utility and component-level defaults with opt-out (`haptic="none"`)
- ensures unsupported/reduced-motion contexts degrade silently

## Test plan
- [x] npm run tc
- [x] npm test